### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is a TypeScript-based MCP server that allows searching for New York Times a
 
 ![NYTimes Article Search](img/example.png)
 
+<a href="https://glama.ai/mcp/servers/ylg4ai4vin"><img width="380" height="200" src="https://glama.ai/mcp/servers/ylg4ai4vin/badge" alt="NYTimes Article Search Server MCP server" /></a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the NYTimes Article Search MCP Server server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/ylg4ai4vin

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.